### PR TITLE
fix: Remove trailing slash from streaming

### DIFF
--- a/src/Mastodon/ApiUrl.elm
+++ b/src/Mastodon/ApiUrl.elm
@@ -247,7 +247,7 @@ statuses =
 -}
 streaming : String
 streaming =
-    apiPrefix ++ "/streaming/"
+    apiPrefix ++ "/streaming"
 
 
 {-| updateMedia


### PR DESCRIPTION
Per the [Mastodon Documentation](https://docs.joinmastodon.org/methods/streaming/#websocket), the endpoint for `streaming` doesn't contain a trailing slash.

[GoToSocial](https://github.com/superseriousbusiness/gotosocial) issues a 301 Redirect to remove the trailing slash, which nodejs websocket libraries don't obey, so it causes the websocket to fail to be created.  This patch should remedy that without any consequences, however I'm spinning up my local dev environment to test this change with gotosocial.
